### PR TITLE
Avoid panic in case of io-errors

### DIFF
--- a/py_tests/test_bloom.py
+++ b/py_tests/test_bloom.py
@@ -3,6 +3,8 @@
 from fastbloom_rs import BloomFilter, FilterBuilder
 import os
 
+import pytest
+
 
 def test_bloom_builder():
     bloom = BloomFilter(100_000_000, 0.01)
@@ -201,3 +203,15 @@ def test_save_load_file():
     assert not bloom.contains('world')
 
     os.remove('fst.bloom')
+
+def test_load_fails():
+    with pytest.raises(FileNotFoundError):
+        BloomFilter.from_file_with_hashes('doesnotexists.bloom')
+
+    with open('fst.bloom', 'xb') as f:
+        try:
+            f.write(b'\00\00')
+            with pytest.raises(OSError):
+                BloomFilter.from_file_with_hashes('fst.bloom')
+        finally:
+            os.remove('fst.bloom')

--- a/src/pybloom.rs
+++ b/src/pybloom.rs
@@ -164,12 +164,12 @@ impl PyBloomFilter {
         Ok(Vec::from(self.bloomfilter.get_u32_array()))
     }
 
-    pub fn save_to_file_with_hashes(&mut self, path: &str) {
-        self.bloomfilter.save_to_file_with_hashes(path);
+    pub fn save_to_file_with_hashes(&mut self, path: &str) -> PyResult<()> {
+        Ok(self.bloomfilter.save_to_file_with_hashes(path)?)
     }
 
-    pub fn save_to_file(&mut self, path: &str) {
-        self.bloomfilter.save_to_file(path);
+    pub fn save_to_file(&mut self, path: &str) -> PyResult<()> {
+        Ok(self.bloomfilter.save_to_file(path)?)
     }
 
     pub fn clear(&mut self) {
@@ -217,12 +217,12 @@ impl PyBloomFilter {
 
     #[staticmethod]
     pub fn from_file_with_hashes(path: &str) -> PyResult<Self> {
-        Ok(PyBloomFilter { bloomfilter: BloomFilter::from_file_with_hashes(path) })
+        Ok(PyBloomFilter { bloomfilter: BloomFilter::from_file_with_hashes(path)? })
     }
 
     #[staticmethod]
     pub fn from_file(path: &str, hashes: u32) -> PyResult<Self> {
-        Ok(PyBloomFilter { bloomfilter: BloomFilter::from_file(path, hashes) })
+        Ok(PyBloomFilter { bloomfilter: BloomFilter::from_file(path, hashes)? })
     }
 }
 


### PR DESCRIPTION
Remove the `.unwrap()`-calls with proper error handling, so `FileNotFoundError` and others can and will be raised instead of simply panicking; see `test_load_fails`.

Also fixes a integer underflow crash in case the file being loaded is shorter than 4 bytes.

Cosmetic changes to unrelated doctests, which failed to compile due to typos.